### PR TITLE
docs: fix quick start docs, it should use 'parse',  instead of 'babel'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import MonacoJSXHighlighter from 'monaco-jsx-highlighter';
 
 // Instantiate the highlighter
 const monacoJSXHighlighter = new MonacoJSXHighlighter(
-   monaco, babel, traverse, aMonacoEditor()
+   monaco, parse, traverse, aMonacoEditor()
 );
 // Activate highlighting (debounceTime default: 100ms)
 monacoJSXHighlighter.highlightOnDidChangeModelContent(100);


### PR DESCRIPTION
A wonderful package! It solve my prolem!

When I use it, I found the docs error in quick start. Has fixed it
 